### PR TITLE
fixes the timezone display issue in API responses and improve reward initialization logic.

### DIFF
--- a/be/app/__init__.py
+++ b/be/app/__init__.py
@@ -47,7 +47,9 @@ def create_app():
 
     # Create tables
     with app.app_context():
-        db.create_all();init_rewards()
+        db.create_all()
+        if not app.config.get("TESTING", False):
+            init_rewards()
 
     # Initialize Flask-Migrate
     migrate.init_app(app, db)

--- a/be/app/__init__.py
+++ b/be/app/__init__.py
@@ -47,7 +47,7 @@ def create_app():
 
     # Create tables
     with app.app_context():
-        db.create_all()
+        db.create_all();init_rewards()
 
     # Initialize Flask-Migrate
     migrate.init_app(app, db)
@@ -68,17 +68,35 @@ def create_app():
 
 
 def init_rewards():
-    rewards = [
-        Reward(type="daily_login", amount=100, description="Daily login reward"),
-        Reward(
-            type="jackpot", amount=500, description="Match 3 symbols to win jackpot"
-        ),
-        Reward(
-            type="free_spin",
-            amount=0,
-            description="Earn a free spin when 'FREE' appears",
-        ),
-    ]
-    db.session.add_all(rewards)
-    db.session.commit()
-    print("Initialized default rewards.")
+    """
+    Initialize default rewards if they don't exist in the database.
+    Avoids duplicate insertions that cause UNIQUE constraint errors.
+    """
+    try:
+        # Retrieve existing reward types (type field).
+        existing = {r.type for r in Reward.query.all()}
+
+        # Define default reward configuration.
+        default_rewards = [
+            {"type": "daily_login", "amount": 100, "description": "Daily login reward"},
+            {"type": "jackpot", "amount": 500, "description": "Match 3 symbols to win jackpot"},
+            {"type": "free_spin", "amount": 0, "description": "Earn a free spin when 'FREE' appears"},
+        ]
+
+        # Check and insert missing rewards
+        added = []
+        for r in default_rewards:
+            if r["type"] not in existing:
+                db.session.add(Reward(**r))
+                added.append(r["type"])
+
+        db.session.commit()
+
+        if added:
+            print(f"Added new reward types: {', '.join(added)}")
+        else:
+            print("All default reward types already exist. No new rewards added.")
+
+    except Exception as e:
+        db.session.rollback()
+        print(f"Failed to initialize rewards: {e}")

--- a/be/app/game_logic.py
+++ b/be/app/game_logic.py
@@ -13,6 +13,7 @@ Rewards include Jackpot points, Free Spins, and Daily Login bonus.
 
 import random
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 class GameLogic:
     # Note: Does not use User object from database or datetime object (Will add later)
@@ -133,13 +134,16 @@ class GameLogic:
         Ensure the user can only claim once per day.
         Returns reward amount or 0 if already claimed.
         """
-        today = datetime.now().date()
-        # First time login (no record in DB yet)
+        # today = datetime.now().date()
+        today_et = datetime.now(ZoneInfo("America/New_York")).date()
+
+        # Allow first-time users to claim reward.
         if not last_login:
             return GameLogic.DAILY_REWARD_POINTS, True
-
+        
         # Compare only the date (ignore time)
-        if last_login.date() < today:
+        last_login_et = (last_login.replace(tzinfo=ZoneInfo("UTC")).astimezone(ZoneInfo("America/New_York")))
+        if last_login_et.date() < today_et:
             return GameLogic.DAILY_REWARD_POINTS, True
 
         # Already logged in today → no reward

--- a/be/app/models.py
+++ b/be/app/models.py
@@ -38,7 +38,7 @@ class User(UserMixin, db.Model):
     xp = db.Column(db.Integer, default=0)         # Experience points
     level = db.Column(db.Integer, default=1)      # User level (default level 1)
     free_spins = db.Column(db.Integer, default=0)  # number of available free spins
-    last_login = db.Column(db.DateTime, default=datetime.utcnow)           # last login time
+    last_login = db.Column(db.DateTime, nullable=True)           # last login time
     
     # One-to-many relationship: A user can have many rewards
     rewards = db.relationship('UserReward', back_populates='user', cascade="all, delete-orphan", lazy=True) 

--- a/be/app/models.py
+++ b/be/app/models.py
@@ -38,7 +38,7 @@ class User(UserMixin, db.Model):
     xp = db.Column(db.Integer, default=0)         # Experience points
     level = db.Column(db.Integer, default=1)      # User level (default level 1)
     free_spins = db.Column(db.Integer, default=0)  # number of available free spins
-    last_login = db.Column(db.DateTime, nullable=True)           # last login time
+    last_login = db.Column(db.DateTime, default=datetime.utcnow)           # last login time
     
     # One-to-many relationship: A user can have many rewards
     rewards = db.relationship('UserReward', back_populates='user', cascade="all, delete-orphan", lazy=True) 

--- a/be/app/routes.py
+++ b/be/app/routes.py
@@ -5,6 +5,8 @@ from flask import Blueprint, request, jsonify
 from app.models import db, User, Reward, UserReward
 from flask_login import login_user, logout_user, login_required
 from app.game_logic import GameLogic
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 
 main = Blueprint('main', __name__)
@@ -143,11 +145,20 @@ def get_rewards(username):
     # Serialize results
     rewards_data = []
     for record in reward_records:
+        if record.claimed_at:
+            # convert UTC → America/New_York
+            claimed_local = record.claimed_at.replace(
+                tzinfo=ZoneInfo("UTC")
+            ).astimezone(ZoneInfo("America/New_York"))
+            claimed_str = claimed_local.strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            claimed_str = None
+
         rewards_data.append({
             "reward_type": record.reward.type,
             "amount": record.reward.amount,
             "description": record.reward.description,
-            "claimed_at": record.claimed_at.strftime("%Y-%m-%d %H:%M:%S")
+            "claimed_at": claimed_str
         })
 
     # Return successful response
@@ -181,14 +192,14 @@ def spin():
 
     # update the balance
     user.balance = new_balance
-    # If the spin rewards include a FREE SPIN, add one
+    # If the spin rewards include a FREE SPIN, add 1 free_spin reward to the record.
     if rewards.get("free_spin"):
         user.free_spins += 1
         reward = Reward.query.filter_by(type="free_spin").first()
         if reward:
             db.session.add(UserReward(user_id=user.id, reward_id=reward.id))
 
-    # If player hits a jackpot
+    # If player hits a jackpot, add jackpot reward to the record.
     if rewards.get("jackpot"):
         reward = Reward.query.filter_by(type="jackpot").first()
         if reward:
@@ -284,20 +295,35 @@ def daily_reward():
         # Commit database changes
         db.session.commit()
 
+        # Convert last_login (after update) to local time for output
+        local_last_login = datetime.utcnow().replace(
+            tzinfo=ZoneInfo("UTC")
+        ).astimezone(ZoneInfo("America/New_York")).strftime("%Y-%m-%d %H:%M:%S")
+
         return jsonify({
             "status": "success",
             "msg": "Daily reward claimed" if granted else "Already claimed today",
             "data": {
                 "username": user.username,
                 "reward_points": reward_points,
-                "balance": user.balance
+                "balance": user.balance,
+                "last_login_local": local_last_login
             }
         }), 200
+
+    # Handle "already claimed today"
+    last_login_str = (
+        user.last_login.replace(
+            tzinfo=ZoneInfo("UTC")
+        ).astimezone(ZoneInfo("America/New_York")).strftime("%Y-%m-%d %H:%M:%S")
+        if user.last_login
+        else None
+    )
     
     return jsonify({
             "status": "error",
             "msg": "Already claimed daily reward today",
-            "data": {"last_login": user.last_login.strftime("%Y-%m-%d")}
+            "data": {"last_login_local": last_login_str}
         }), 404
 
 # List all available rewards
@@ -330,7 +356,7 @@ def list_rewards():
             "amount": r.amount,
             "description": r.description,
             "created_at": r.created_at.isoformat() if r.created_at else None
-        }
+        } 
         for r in rewards
     ]
 

--- a/be/tests/conftest.py
+++ b/be/tests/conftest.py
@@ -7,7 +7,7 @@
 import pytest
 from app.__init__ import create_app, db
 from config import TestConfig
-from app.models import User
+from app.models import User, Reward
 
 
 # fixture to start the app in testing mode
@@ -17,6 +17,10 @@ def app():
     app.config["TESTING"] = True
     with app.app_context():
         db.create_all()
+         # Clear the reward table here to avoid unique constraint conflicts.
+        Reward.query.delete()
+        db.session.commit()
+
         yield app
         db.session.remove()
         db.drop_all()  # clean up after test


### PR DESCRIPTION
This pr fixes the timezone display issue in API responses and improve reward initialization logic.

- Updated /rewards/<username> and /daily-reward routes to show timestamps in America/New_York (US Eastern Time) instead of UTC.

- Keeps UTC storage in database for consistency, but converts to local time in JSON responses.

- Updated init_rewards() in __init__.py to avoid duplicate reward initialization and log existing types gracefully.